### PR TITLE
Add enabled config to models without it

### DIFF
--- a/.buildkite/scripts/run_models.sh
+++ b/.buildkite/scripts/run_models.sh
@@ -19,7 +19,7 @@ dbt deps
 dbt seed --target "$db" --full-refresh
 dbt run --target "$db" --full-refresh
 dbt test --target "$db"
-dbt run --vars '{zuora__using_credit_balance_adjustment: false, zuora__using_taxation_item: false, zuora__using_refund: false, zuora__using_refund_invoice_payment: false}' --target "$db" 
-dbt test --target '{zuora__using_credit_balance_adjustment: false, zuora__using_taxation_item: false, zuora__using_refund: false, zuora__using_refund_invoice_payment: false}' --target "$db"
+dbt run --vars '{zuora__using_account: false, zuora__using_amendment: false, zuora__using_contact: false, zuora__using_credit_balance_adjustment: false, zuora__using_invoice_item: false, zuora__using_invoice_payment: false, zuora__using_invoice: false, zuora__using_order: false, zuora__using_payment_method: false, zuora__using_payment: false, zuora__using_product_rate_plan_charge: false, zuora__using_product_rate_plan: false, zuora__using_product: false, zuora__using_product_rate_plan_charge: false, zuora__using_rate_plan: false, zuora__using_refund_invoice_payment: false zuora__using_refund: false, zuora__using_subscription: false, zuora__using_taxation_item: false}' --target "$db" 
+dbt test --target '{zuora__using_account: false, zuora__using_amendment: false, zuora__using_contact: false, zuora__using_credit_balance_adjustment: false, zuora__using_invoice_item: false, zuora__using_invoice_payment: false, zuora__using_invoice: false, zuora__using_order: false, zuora__using_payment_method: false, zuora__using_payment: false, zuora__using_product_rate_plan_charge: false, zuora__using_product_rate_plan: false, zuora__using_product: false, zuora__using_product_rate_plan_charge: false, zuora__using_rate_plan: false, zuora__using_refund_invoice_payment: false zuora__using_refund: false, zuora__using_subscription: false, zuora__using_taxation_item: false}' --target "$db"
 
 dbt run-operation fivetran_utils.drop_schemas_automation --target "$db"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # dbt_zuora_source v0.2.2
-## TO-DO: [PR #12](https://github.com/fivetran/dbt_zuora_source/pull/12) includes the following update:
+[PR #12](https://github.com/fivetran/dbt_zuora_source/pull/12) includes the following update:
 ## 🔧 Bug Fixes
 - Add model enable variable config to the following models in order to ensure they do not run when the variable is set to `false`:
   - `stg_zuora__account` and `stg_zuora__account_tmp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# dbt_zuora_source v0.2.2
+## TO-DO: [PR #]() includes the following update:
+## 🔧 Bug Fixes
+- Add model enable variable config to the following models in order to ensure they do not run when the variable is set to `false`:
+  - `stg_zuora__account` and `stg_zuora__account_tmp`
+  - `stg_zuora__amendment` and `stg_zuora__amendment_tmp`
+  - `stg_zuora__contact` and `stg_zuora__contact_tmp`
+  - `stg_zuora__invoice_item` and stg_zuora__invoice_item_tmp`
+  - `stg_zuora__invoice_payment` and `stg_zuora__invoice_payment_tmp`
+  - `stg_zuora__invoice` and `stg_zuora__invoice_tmp`
+  - `stg_zuora__order` and `stg_zuora__order_tmp`
+  - `stg_zuora__payment_method` and `stg_zuora__payment_method_tmp`
+  - `stg_zuora__payment` and `stg_zuora__payment_tmp`
+  - `stg_zuora__product_rate_plan_charge` and `stg_zuora__product_rate_plan_charge_tmp`
+  - `stg_zuora__product_rate_plan` and `stg_zuora__product_rate_plan_tmp`
+  - `stg_zuora__subscription` and `stg_zuora__subscription_tmp`
+
 # dbt_zuora_source v0.2.1
 [PR #11](https://github.com/fivetran/dbt_zuora_source/pull/11) includes the following update:
 ## 🔧 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # dbt_zuora_source v0.2.2
-## TO-DO: [PR #]() includes the following update:
+## TO-DO: [PR #12](https://github.com/fivetran/dbt_zuora_source/pull/12) includes the following update:
 ## 🔧 Bug Fixes
 - Add model enable variable config to the following models in order to ensure they do not run when the variable is set to `false`:
   - `stg_zuora__account` and `stg_zuora__account_tmp`

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'zuora_source'
-version: '0.2.1'
+version: '0.2.2'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 

--- a/models/stg_zuora__account.sql
+++ b/models/stg_zuora__account.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_account', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__amendment.sql
+++ b/models/stg_zuora__amendment.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_amendment', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__contact.sql
+++ b/models/stg_zuora__contact.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_contact', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__invoice.sql
+++ b/models/stg_zuora__invoice.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_invoice', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__invoice_item.sql
+++ b/models/stg_zuora__invoice_item.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_invoice_item', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__invoice_payment.sql
+++ b/models/stg_zuora__invoice_payment.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_invoice_payment', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__order.sql
+++ b/models/stg_zuora__order.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_order', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__payment.sql
+++ b/models/stg_zuora__payment.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_payment', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__payment_method.sql
+++ b/models/stg_zuora__payment_method.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_payment_method', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__product.sql
+++ b/models/stg_zuora__product.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_product', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__product_rate_plan.sql
+++ b/models/stg_zuora__product_rate_plan.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_product_rate_plan', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__product_rate_plan_charge.sql
+++ b/models/stg_zuora__product_rate_plan_charge.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_product_rate_plan_charge', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__rate_plan.sql
+++ b/models/stg_zuora__rate_plan.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_rate_plan', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__rate_plan_charge.sql
+++ b/models/stg_zuora__rate_plan_charge.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_product_rate_plan_charge', true)) }}
 
 with base as (
 

--- a/models/stg_zuora__subscription.sql
+++ b/models/stg_zuora__subscription.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=var('zuora__using_subscription', true)) }}
 
 with base as (
 

--- a/models/tmp/stg_zuora__account_tmp.sql
+++ b/models/tmp/stg_zuora__account_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_account', true)) }}
+
 select * 
 from {{ var('account') }}

--- a/models/tmp/stg_zuora__amendment_tmp.sql
+++ b/models/tmp/stg_zuora__amendment_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_amendment', true)) }}
+
 select * 
 from {{ var('amendment') }}

--- a/models/tmp/stg_zuora__contact_tmp.sql
+++ b/models/tmp/stg_zuora__contact_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_contact', true)) }}
+
 select * 
 from {{ var('contact') }}

--- a/models/tmp/stg_zuora__invoice_item_tmp.sql
+++ b/models/tmp/stg_zuora__invoice_item_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_invoice_item', true)) }}
+
 select * 
 from {{ var('invoice_item') }}

--- a/models/tmp/stg_zuora__invoice_payment_tmp.sql
+++ b/models/tmp/stg_zuora__invoice_payment_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_invoice_payment', true)) }}
+
 select * 
 from {{ var('invoice_payment') }}

--- a/models/tmp/stg_zuora__invoice_tmp.sql
+++ b/models/tmp/stg_zuora__invoice_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_invoice', true)) }}
+
 select * 
 from {{ var('invoice') }}

--- a/models/tmp/stg_zuora__order_tmp.sql
+++ b/models/tmp/stg_zuora__order_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_order', true)) }}
+
 select * 
 from {{ var('order') }}

--- a/models/tmp/stg_zuora__payment_method_tmp.sql
+++ b/models/tmp/stg_zuora__payment_method_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_payment_method', true)) }}
+
 select * 
 from {{ var('payment_method') }}

--- a/models/tmp/stg_zuora__payment_tmp.sql
+++ b/models/tmp/stg_zuora__payment_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_payment', true)) }}
+
 select * 
 from {{ var('payment') }}

--- a/models/tmp/stg_zuora__product_rate_plan_charge_tmp.sql
+++ b/models/tmp/stg_zuora__product_rate_plan_charge_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_product_rate_plan_charge', true)) }}
+
 select * 
 from {{ var('product_rate_plan_charge') }}

--- a/models/tmp/stg_zuora__product_rate_plan_tmp.sql
+++ b/models/tmp/stg_zuora__product_rate_plan_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_product_rate_plan', true)) }}
+
 select * 
 from {{ var('product_rate_plan') }}

--- a/models/tmp/stg_zuora__product_tmp.sql
+++ b/models/tmp/stg_zuora__product_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_product', true)) }}
+
 select * 
 from {{ var('product') }}

--- a/models/tmp/stg_zuora__rate_plan_charge_tmp.sql
+++ b/models/tmp/stg_zuora__rate_plan_charge_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_product_rate_plan_charge', true)) }}
+
 select * 
 from {{ var('rate_plan_charge') }}

--- a/models/tmp/stg_zuora__rate_plan_tmp.sql
+++ b/models/tmp/stg_zuora__rate_plan_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_rate_plan', true)) }}
+
 select * 
 from {{ var('rate_plan') }}

--- a/models/tmp/stg_zuora__subscription_tmp.sql
+++ b/models/tmp/stg_zuora__subscription_tmp.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=var('zuora__using_subscription', true)) }}
+
 select * 
 from {{ var('subscription') }}


### PR DESCRIPTION
**Please provide your name and company**

Santina Brohen, Pleo

**Link the issue/feature request which this PR is meant to address**
<!--- If an issue was not created, please create one first so we may discuss the PR prior to opening one. -->

Link to issue [here](https://github.com/fivetran/dbt_zuora/issues/32).

Some context here as well:
Currently, the package expects certain sources to be available. Some models, but not all, include the enabled config, which makes it possible to skip the model if the source is not available. For example, `stg_zuora__credit_balance_adjustment` includes the following: `{{ config(enabled=var('zuora__using_credit_balance_adjustment', true)) }}` (code [here](https://github.com/fivetran/dbt_zuora_source/blob/main/models/stg_zuora__credit_balance_adjustment.sql#L1)). Of the 19 models, only 4 can be disabled:
- `stg_zuora__credit_balance_adjustment`
- `stg_zuora__refund`
- `stg_zuora__refund_invoice_payment`
- `stg_zuora__taxation_item`

At Pleo, we are not ingesting all the sources that are expected by the package, so even when leveraging the enabled config in the models where it's available, we are still left with models raising errors.

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**

With this PR, it is possible to disable any model, not just the subset listed above. Having the ability to disable models for which the sources are not ingested via Fivetran is a great feature, and it opens up use of this package even when only a few Fivetran sources are available.

**How did you validate the changes introduced within this PR?**

As recommended by you [here](https://github.com/fivetran/dbt_zuora_source/tree/v0.2.1/?tab=readme-ov-file#contributions), I followed [this dbt Discourse article](https://discourse.getdbt.com/t/contributing-to-a-dbt-package/657) to contribute.

Before making the changes, we had four models that raised errors because the sources are not available. I ran `dbt build --select +zuora_source` and the following shows the error:

![Screenshot 2024-02-26 at 16 08 21](https://github.com/fivetran/dbt_zuora_source/assets/117174676/2688b06b-3ed3-462f-9599-80cc9cf8cdb5)

After making the changes and disabling the models for sources we do not ingest, I ran `dbt build --select +zuora_source` again; no errors were raised.

![Screenshot 2024-02-27 at 16 06 12](https://github.com/fivetran/dbt_zuora_source/assets/117174676/38be3b10-c8cb-439f-8d3d-b5c897a69be5)

![Screenshot 2024-02-27 at 16 04 27](https://github.com/fivetran/dbt_zuora_source/assets/117174676/dbf9b428-b59b-4482-836d-2bce5d262fcf)

I then removed one of the new variables to ensure that it still correctly raised an error; it did:

![Screenshot 2024-02-27 at 16 08 12](https://github.com/fivetran/dbt_zuora_source/assets/117174676/e702d54d-e46f-4447-9b5e-5cc775810721)
Note: `zuora__using_contact: false` is commented out.

![Screenshot 2024-02-27 at 16 09 10](https://github.com/fivetran/dbt_zuora_source/assets/117174676/9a5eb5b3-844a-430a-9266-8cd97427b27b)

**Which warehouse did you use to develop these changes?**
BigQuery

**Did you update the CHANGELOG?**
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🦄 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.

**PR Template** 
- [Community Pull Request Template](?expand=1&template=pull_request_template.md) (default)

- [Maintainer Pull Request Template](?expand=1&template=maintainer_pull_request_template.md) (to be used by maintainers)
